### PR TITLE
[FEATURE] Change the store code in Swagger based on a param

### DIFF
--- a/guides/v2.0/rest/generate-local.md
+++ b/guides/v2.0/rest/generate-local.md
@@ -55,6 +55,26 @@ To return information about all services:
 <p>You must specify an authorization token for an {% glossarytooltip 29ddb393-ca22-4df9-a8d4-0024d75739b1 %}admin{% endglossarytooltip %} user to return information for most endpoints. See <a href="{{page.baseurl}}get-started/authentication/gs-authentication-token.html">Token-based authentication</a> for more information. </p>
 </div>
 
+
+## Return the JSON schema for a specific store in Swagger
+
+Through Swagger it is possible to test the different REST API Calls. By default the resources will be fetched for all storeviews as shown in the example below. To return the JSON Schema for a specific store by adding a store parameter to the url with the `store_code` of the specific store.
+
+Default Swagger Url:
+  `http://<magento_host>/swagger`
+
+Fetched JSON schema url:
+  `http://<magento_host>/rest/all/schema?services=all`
+  
+---
+
+Specified Storecode in Swagger Url:
+  `http://<magento_host>/swagger?store=default`
+  
+Fetched JSON schema url:
+  `http://<magento_host>/rest/default/schema?services=all`
+
+
 <h2>Related topics</h2>
 
 [Token-based authentication]({{page.baseurl}}get-started/authentication/gs-authentication-token.html)


### PR DESCRIPTION
This feature makes it possible to easily switch between store codes in Swagger without changing the swagger-ui template but through adding a store param to the url. With this feature it is possible to test API calls in Swagger for different storeviews.

See following pull request for additional information:

https://github.com/magento-partners/magento2ce/pull/10

https://github.com/magento-partners/magento2ce/pull/9

https://github.com/magento/magento2/pull/10557